### PR TITLE
Implement mentioning (pinging) discord roles from Telegram

### DIFF
--- a/lib/telegram2discord/handleEntities.js
+++ b/lib/telegram2discord/handleEntities.js
@@ -48,10 +48,11 @@ function handleEntities(text, entities, dcBot, bridge) {
 		switch (e.type) {
 			case "mention":
 			case "text_mention": {
-				// A mention. Substitute the Discord user ID if one exists
-				const username = part.substring(1);
-				const dcUser = dcBot.channels.get(bridge.discord.channelId).members.find("displayName", username);
-				substitute = dcUser !== null ? `<@${dcUser.id}>` : part;
+				// A mention. Substitute the Discord user ID or Discord role ID if one exists
+				const mentionable = part.substring(1);
+				const dcUser = dcBot.channels.get(bridge.discord.channelId).members.find("displayName", mentionable);
+				const dcRole = dcBot.guilds.get(bridge.discord.serverId).roles.find("name", mentionable);
+				substitute = dcUser !== null ? `<@${dcUser.id}>` : `<@&${dcRole.id}>`;
 				break;
 			}
 			case "code": {

--- a/lib/telegram2discord/handleEntities.js
+++ b/lib/telegram2discord/handleEntities.js
@@ -52,7 +52,7 @@ function handleEntities(text, entities, dcBot, bridge) {
 				const mentionable = part.substring(1);
 				const dcUser = dcBot.channels.get(bridge.discord.channelId).members.find("displayName", mentionable);
 				const dcRole = dcBot.guilds.get(bridge.discord.serverId).roles.find("name", mentionable);
-				substitute = dcUser !== null ? `<@${dcUser.id}>` : `<@&${dcRole.id}>`;
+				substitute = dcUser !== null ? `<@${dcUser.id}>` : dcRole !== null ? `<@&${dcRole.id}>` : mentionable;
 				break;
 			}
 			case "code": {


### PR DESCRIPTION
Hi @Suppen, please review this change that implements mentioning a discord role.

Setup:
1. Set up a role on your discord server. It will be assigned an id, example: `@myRole` = `<@&446919483534082051>`
2. This code chunk will parse the guild for roles matching the name

Open to feedback. 

Regards,
Perry Yan