### PR TITLE
Add simple Discord-Tenor-GIF to Telegram support

### DIFF
--- a/lib/discord2telegram/setup.js
+++ b/lib/discord2telegram/setup.js
@@ -181,20 +181,31 @@ function setup(logger, dcBot, tgBot, messageMap, bridgeMap, settings) {
 
 					// Pass the message on to Telegram
 					try {
-						const textToSend = bridge.discord.sendUsernames
-							? `<b>${senderName}</b>\n${processedMessage}`
-							: processedMessage
-						;
-						const tgMessage = await tgBot.telegram.sendMessage(
-							bridge.telegram.chatId,
-							textToSend,
-							{
-								parse_mode: "HTML"
-							}
-						);
+						if(processedMessage.startsWith("https://tenor.com"))
+                                                {
+                                                        const tgMessage = await tgBot.telegram.sendVideo(
+                                                                bridge.telegram.chatId,
+                                                                processedMessage
+                                                        );
+                                                        // Make the mapping so future edits can work
+                                                        messageMap.insert(MessageMap.DISCORD_TO_TELEGRAM, bridge, message.id, tgMessage.message_id);
+                                                }
+                                                else {
+                                                        const textToSend = bridge.discord.sendUsernames
+                                                                ? `<b>${senderName}</b>\n${processedMessage}`
+                                                                : processedMessage
+                                                        ;
+                                                        const tgMessage = await tgBot.telegram.sendMessage(
+                                                                bridge.telegram.chatId,
+                                                                textToSend,
+                                                                {
+                                                                        parse_mode: "HTML"
+                                                                }
+                                                        );
 
-						// Make the mapping so future edits can work
-						messageMap.insert(MessageMap.DISCORD_TO_TELEGRAM, bridge, message.id, tgMessage.message_id);
+                                                        // Make the mapping so future edits can work
+                                                        messageMap.insert(MessageMap.DISCORD_TO_TELEGRAM, bridge, message.id, tgMessage.message_id);
+                                                }
 					} catch (err) {
 						logger.error(`[${bridge.name}] Telegram did not accept a message:`, err);
 						logger.error(`[${bridge.name}] Failed message:`, err);


### PR DESCRIPTION
Probably not optimal yet, but it works for forwarding Discord-Tenor GIFs to Telegram. 
I just wanted to share this basic approach of forwarding gifs bidirectional.