### PR TITLE
Correct the case of the chatinfo message in telegram.

### DIFF
--- a/lib/telegram2discord/setup.js
+++ b/lib/telegram2discord/setup.js
@@ -121,7 +121,7 @@ const createMessageHandler = R.curry((logger, tgBot, bridgeMap, settings, func, 
 		// This is a request for chat info. Give it, no matter which chat this is from
 		tgBot.telegram.sendMessage(
 			message.chat.id,
-			"chatID: " + message.chat.id
+			"chatId: " + message.chat.id
 		);
 
 		return;


### PR DESCRIPTION
I copied and pasted the chatID as output in telegram. This did not work, as it is expecting chatId in the settings.yaml.