### PR TITLE
Moved settings logic into main.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ ADD . .
 
 RUN npm install --production
 
-# Hack to make the settings file work from the data/ directory
-# Remove this line if you build with the settings file integrated
-RUN ln -s data/settings.yaml settings.yaml
-
 VOLUME /opt/TediCross/data/
 
 ENTRYPOINT /usr/local/bin/npm start

--- a/main.js
+++ b/main.js
@@ -53,7 +53,16 @@ const settingsPathYAML = args.config;
 migrateSettingsToYAML(settingsPathJSON, settingsPathYAML);
 
 // Get the settings
-const rawSettingsObj = jsYaml.safeLoad(fs.readFileSync(settingsPathYAML));
+try {
+	const rawSettingsObj = jsYaml.safeLoad(fs.readFileSync(settingsPathYAML));
+} catch (err){
+	if (err.code === "ENOENT") {
+		// We might be in a container, try to account for that and try again
+		const containerSettingsPathYAML = path.join("data", settingsPathYAML)
+		const const rawSettingsObj = jsYaml.safeLoad(fs.readFileSync(containerSettingsPathYAML)
+	}
+}
+							     
 const settings = Settings.fromObj(rawSettingsObj);
 
 // Initialize logger

--- a/main.js
+++ b/main.js
@@ -58,8 +58,8 @@ try {
 } catch (err){
 	if (err.code === "ENOENT") {
 		// We might be in a container, try to account for that and try again
-		const containerSettingsPathYAML = path.join("data", settingsPathYAML)
-		const const rawSettingsObj = jsYaml.safeLoad(fs.readFileSync(containerSettingsPathYAML)
+		const containerSettingsPathYAML = path.join(__dirname, "data", "settings.yaml")
+		const rawSettingsObj = jsYaml.safeLoad(fs.readFileSync(containerSettingsPathYAML))
 	}
 }
 							     

--- a/main.js
+++ b/main.js
@@ -51,17 +51,20 @@ const args = yargs
 const settingsPathJSON = path.join(__dirname, "settings.json");
 const settingsPathYAML = args.config;
 migrateSettingsToYAML(settingsPathJSON, settingsPathYAML);
-
-// Get the settings
-try {
-	const rawSettingsObj = jsYaml.safeLoad(fs.readFileSync(settingsPathYAML));
-} catch (err){
-	if (err.code === "ENOENT") {
-		// We might be in a container, try to account for that and try again
-		const containerSettingsPathYAML = path.join(__dirname, "data", "settings.yaml")
-		const rawSettingsObj = jsYaml.safeLoad(fs.readFileSync(containerSettingsPathYAML))
+ 
+// Get the settings from a function
+function getSettings(){
+	try {
+		return jsYaml.safeLoad(fs.readFileSync(settingsPathYAML));
+	} catch (err){
+		if (err.code === "ENOENT") {
+			// We might be in a container, try to account for that and try again
+			const containerSettingsPathYAML = path.join(__dirname, "data", "settings.yaml")
+			return jsYaml.safeLoad(fs.readFileSync(containerSettingsPathYAML))
+		}
 	}
 }
+const rawSettingsObj = getSettings()
 							     
 const settings = Settings.fromObj(rawSettingsObj);
 


### PR DESCRIPTION
I've moved the settings logic into main.js. It's a little less hacky than using a symlink when the container is created, and adds some consistency between container and non-container based deployments. I was also having issues with that symlink from the container, see #111 

I'm not a javascript or node developer normally though, so there may have been a reason the settings weren't done this way to start with.