### PR TITLE
Relay playable telegram voice message to discord

### DIFF
--- a/src/telegram2discord/middlewares.js
+++ b/src/telegram2discord/middlewares.js
@@ -483,7 +483,7 @@ function addFileObj(ctx, next) {
 		ctx.tediCross.file = {
 			type: "voice",
 			id: message.voice.file_id,
-			name: "voice" + "." + mime.getExtension(message.voice.mime_type)
+			name: "voice" + "." + mime.getExtension(message.voice.mime_type).replace('oga', 'ogg')
 		};
 	}
 


### PR DESCRIPTION
Telegram makes a file with the file extension `oga`. Discord does not support this. However, as discovered in #153, discord supports `ogg`, which it also has no problem on playing even if the original file is a `oga` file.

This PR simply renames the file extension on voice messages from `oga` to `ogg`