### PR TITLE
D2T: Add link and image support for discord embeds

### DIFF
--- a/src/discord2telegram/md2html.ts
+++ b/src/discord2telegram/md2html.ts
@@ -108,6 +108,8 @@ export function md2html(text: string) {
 				return html + "\n";
 			} else if (node.type === "hr") {
 				return html + "---";
+			} else if (node.type === "link") {
+				return `<a href="${node.target}">${extractText(node)}</a>`;
 			}
 
 			// Turn the nodes into HTML

--- a/src/discord2telegram/md2html.ts
+++ b/src/discord2telegram/md2html.ts
@@ -109,7 +109,7 @@ export function md2html(text: string) {
 			} else if (node.type === "hr") {
 				return html + "---";
 			} else if (node.type === "link") {
-				return `<a href="${node.target}">${extractText(node)}</a>`;
+				return html + `<a href="${node.target}">${extractText(node)}</a>`;
 			}
 
 			// Turn the nodes into HTML

--- a/src/discord2telegram/setup.ts
+++ b/src/discord2telegram/setup.ts
@@ -182,7 +182,21 @@ export function setup(
 
 					// Convert it to something Telegram likes
 					const text = handleEmbed(embed, senderName);
-
+					
+					// Handle embed with image, send it as photo with caption
+					if (embed.image != null) {
+						try {
+							// Send photo with caption
+							tgBot.telegram.sendPhoto(bridge.telegram.chatId, embed.image.url, {
+								caption: text,
+								parse_mode: "HTML"
+							});
+						} catch (err) {
+							logger.error(`[${bridge.name}] Telegram did not accept an embed:`, err);
+						}
+						return;
+					}
+					
 					try {
 						// Send it
 						tgBot.telegram.sendMessage(bridge.telegram.chatId, text, {


### PR DESCRIPTION
Added very crude support for links and images in discord embeds.
* When node type is link we create proper a tag for telegram.
* When embed contains image then send message to telegram as photo and rest of the embed fields as caption.