### PR TITLE
Added four new helpers for discord2telegram processing

### DIFF
--- a/src/discord2telegram/helpers.ts
+++ b/src/discord2telegram/helpers.ts
@@ -27,3 +27,52 @@ export const escapeHTMLSpecialChars = R.compose(
 	R.replace(/</g, "&lt;"),
 	R.replace(/&/g, "&amp;")
 );
+
+/**
+ * Filters custom emojis from the output
+ *
+ * @param input The string that needs to be filtered
+ *
+ * @returns Filtered string
+ */
+export function customEmojiFilter(input: string){
+	const regex = /\&lt;[^;]*\&gt;/gi;
+	return input.split(regex).join('');
+}
+
+/**
+ * Replaces @ with # to prevent unneeded references in Telegram
+ *
+ * @param input The string that needs to be processed
+ *
+ * @returns Processed string
+ */
+export function replaceAtWithHash(input: string){
+	const regex = /\@/g;
+	return input.replace(regex, '#');
+}
+
+/**
+ * Replaces excessive (two or more) whitespaces with a single one
+ *
+ * @param input The string that needs to be processed
+ *
+ * @returns Processed string
+ */
+export function replaceExcessiveSpaces(input: string){
+	const regex = /[^\S\n]{2,}/g;
+	return input.replace(regex, ' ');
+}
+
+/**
+ * Removes whitespaces if they're placed at the beginning of the newline
+ *
+ * @param input The string that needs to be processed
+ *
+ * @returns Processed string
+ */
+export function removeNewlineSpaces(input: string){
+	const regex = /^[^\S\n]*/gm;
+	return input.replace(regex, '');
+}
+

--- a/src/discord2telegram/md2html.ts
+++ b/src/discord2telegram/md2html.ts
@@ -1,5 +1,5 @@
 import simpleMarkdown, { SingleASTNode } from "simple-markdown";
-import { escapeHTMLSpecialChars } from "./helpers";
+import { escapeHTMLSpecialChars, customEmojiFilter, replaceAtWithHash, replaceExcessiveSpaces, removeNewlineSpaces } from "./helpers";
 import R from "ramda";
 
 /***********
@@ -119,5 +119,18 @@ export function md2html(text: string) {
 			return html + `${tags.start}${extractText(node)}${tags.end}`;
 		}, "");
 
-	return html;
+	// Making a couple of formatting adjustments 
+	function htmlCleanup(input: string){
+		// Removing custom emojis from the HTML
+		input = customEmojiFilter(input)
+		// Replacing @ character with # character to prevent unintentional references in Telegram
+		input = replaceAtWithHash(input)
+		// Replacing excessive whitespaces with a single space (tends to be an issue after custom emoji filtering)
+		input = replaceExcessiveSpaces(input)
+		// Removing whitespaces if they're placed on the beginning of the newline (tends to be an issue after custom emoji filtering)
+		input = removeNewlineSpaces(input)
+		return input;
+	}
+	
+	return htmlCleanup(html);
 }


### PR DESCRIPTION
**Added 4 new helpers to clean up output when using discord2telegram processing**

1. Added **customEmojiFilter** helper function that will filter out custom emojis (uploaded to discord server by user). Why: otherwise they're displayed in raw html format, since there're no emojis to translate them to;
2. Added **replaceAtWithHash** helper function that will filter replace '@' with '#'. Why: '@' is used as an inner reference symbol in Telegram which leads to posts transferred from Discord (if they had any @-mentions in it) to have a lot of unexpected links leading to random channels;
3. Added **replaceExcessiveSpaces** helper function that will filter out excessive (2 or more) whitespaces from the output. Why: after removing custom emojis html output frequently ends up with excessive spaces;
4. Added **removeNewlineSpaces** helper function that will filter out whitespaces placed at the beginning of the newline. Why: after removing custom emojis that were placed at the beginning of the newline html output ends up with an unneeded space;