### PR TITLE
Added three new optional helpers for discord2telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ As mentioned in the step by step installation guide, there is a settings file. H
 	* `colonAfterSenderName`: Whether or not to put a colon after the name of the sender in messages from Discord to Telegram. If true, the name is displayed `Name:`. If false, it is displayed `Name`. Defaults to false
 	* `skipOldMessages`: Whether or not to skip through all previous messages cached from the telegram-side and start processing new messages ONLY. Defaults to true. Note that there is no guarantee the old messages will arrive at Discord in order
 	* `sendEmojiWithStickers`: Whether or not to send the corresponding emoji when relaying stickers to Discord
+	* `filterCustomEmojis`: Determines what to do with custom emojis from Discord message before it reaches telegram. Has three states:
+		01. `default` - custom emojis will be transferred without any processing (ex: <:emojisnhead:1102667149627113602> My Text);
+		02. `remove` - custom emojis will be removed from the output (ex: My Text);
+		03. `replace` - custom emojis will be replaced with a definable string. Defined in `replaceCustomEmojisWith` (ex: 🔹 My Text).
+		Defaults to `default`
+	* `replaceCustomEmojisWith`: Determines a string that will be used as a replacement for custom emojis. Anything that can be passed as a string is supported, including emojis. Defaults to `🔹`
+	* `replaceAtSign`: Whether or not to replace `@` sign to something else from Discord message before it reaches. When set to `true` will replace `@` with a string you put into `settings.replaceAtSignWith`. If set to `false` - will do nothing. Defaults to `false`
+	* `replaceAtSignWith`: Determines the string that will be used as a replacement for `@` sign. Anything that can be passed as a string is supported, including emojis. Defaults to `#`
+	* `removeExcessiveSpacings`: **USE WITH CAUTION** Whether or not to remove excessive (2 or more) `whitespaces` from Discord message. Can help to neat your message up if it wasn't particulary untidy in the source. When set to `true` will remove excessive `whitespaces` and replace them with a single `whitespace` instead. If set to `false` - will do nothing. Defaults to `false`
 * `discord`: Object authorizing and defining the Discord bot's behavior
 	* `token`: The Discord bot's token. It is needed for the bot to authenticate to the Discord servers and be able to send and receive messages. If set to `"env"`, TediCross will read the token from the environment variable `DISCORD_BOT_TOKEN`
 	* `skipOldMessages`: Whether or not to skip through all previous messages sent since the bot was last turned off and start processing new messages ONLY. Defaults to true. Note that there is no guarantee the old messages will arrive at Telegram in order. **NOTE:** [Telegram has a limit](https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this) on how quickly a bot can send messages. If there is a big backlog, this will cause problems

--- a/src/discord2telegram/helpers.ts
+++ b/src/discord2telegram/helpers.ts
@@ -35,21 +35,35 @@ export const escapeHTMLSpecialChars = R.compose(
  *
  * @returns Filtered string
  */
-export function customEmojiFilter(input: string){
-	const regex = /\&lt;[^;]*\&gt;/gi;
+export function removeCustomEmojis(input: string){
+	const regex = /\&lt;[^;]*\&gt;\s?/gi;
 	return input.split(regex).join('');
+}
+
+/**
+ * Replaces custom emojis with a definable custom string
+ *
+ * @param input The string that needs to be processed
+ * @param replacement The string that will be used as a replacement for custom emojis
+ *
+ * @returns Filtered string
+ */
+export function replaceCustomEmojis(input: string, replacement: string){
+	const regex = /\&lt;[^;]*\&gt;/g;
+	return input.replace(regex, replacement);
 }
 
 /**
  * Replaces @ with # to prevent unneeded references in Telegram
  *
  * @param input The string that needs to be processed
+ * @param replacement The string that will be used as a replacement for @ in the output
  *
  * @returns Processed string
  */
-export function replaceAtWithHash(input: string){
+export function replaceAtWith(input: string, replacement: string ){
 	const regex = /\@/g;
-	return input.replace(regex, '#');
+	return input.replace(regex, replacement);
 }
 
 /**
@@ -62,17 +76,5 @@ export function replaceAtWithHash(input: string){
 export function replaceExcessiveSpaces(input: string){
 	const regex = /[^\S\n]{2,}/g;
 	return input.replace(regex, ' ');
-}
-
-/**
- * Removes whitespaces if they're placed at the beginning of the newline
- *
- * @param input The string that needs to be processed
- *
- * @returns Processed string
- */
-export function removeNewlineSpaces(input: string){
-	const regex = /^[^\S\n]*/gm;
-	return input.replace(regex, '');
 }
 

--- a/src/discord2telegram/md2html.ts
+++ b/src/discord2telegram/md2html.ts
@@ -1,6 +1,7 @@
 import simpleMarkdown, { SingleASTNode } from "simple-markdown";
-import { escapeHTMLSpecialChars, customEmojiFilter, replaceAtWithHash, replaceExcessiveSpaces, removeNewlineSpaces } from "./helpers";
+import { escapeHTMLSpecialChars } from "./helpers";
 import R from "ramda";
+
 
 /***********
  * Helpers *
@@ -119,18 +120,5 @@ export function md2html(text: string) {
 			return html + `${tags.start}${extractText(node)}${tags.end}`;
 		}, "");
 
-	// Making a couple of formatting adjustments 
-	function htmlCleanup(input: string){
-		// Removing custom emojis from the HTML
-		input = customEmojiFilter(input)
-		// Replacing @ character with # character to prevent unintentional references in Telegram
-		input = replaceAtWithHash(input)
-		// Replacing excessive whitespaces with a single space (tends to be an issue after custom emoji filtering)
-		input = replaceExcessiveSpaces(input)
-		// Removing whitespaces if they're placed on the beginning of the newline (tends to be an issue after custom emoji filtering)
-		input = removeNewlineSpaces(input)
-		return input;
-	}
-	
-	return htmlCleanup(html);
+	return html;
 }

--- a/src/discord2telegram/md2html.ts
+++ b/src/discord2telegram/md2html.ts
@@ -2,7 +2,6 @@ import simpleMarkdown, { SingleASTNode } from "simple-markdown";
 import { escapeHTMLSpecialChars } from "./helpers";
 import R from "ramda";
 
-
 /***********
  * Helpers *
  ***********/

--- a/src/settings/TelegramSettings.ts
+++ b/src/settings/TelegramSettings.ts
@@ -4,6 +4,11 @@ interface SettingProperties {
 	colonAfterSenderName: boolean;
 	sendEmojiWithStickers: boolean;
 	useFirstNameInsteadOfUsername: boolean;
+	filterCustomEmojis: string;
+	replaceCustomEmojisWith: string;
+	replaceAtSign: boolean;
+	replaceAtSignWith: string;
+	removeExcessiveSpacings: boolean;
 }
 
 /******************************
@@ -17,6 +22,11 @@ export class TelegramSettings {
 	colonAfterSenderName: boolean;
 	skipOldMessages: boolean;
 	sendEmojiWithStickers: boolean;
+	filterCustomEmojis: string;
+	replaceCustomEmojisWith: string;
+	replaceAtSign: boolean;
+	replaceAtSignWith: string;
+	removeExcessiveSpacings: boolean;
 
 	/**
 	 * Creates a new TelegramSettings object
@@ -27,7 +37,11 @@ export class TelegramSettings {
 	 * @param settings.colonAfterSenderName Whether or not to put a colon after the name of the sender in messages from Discord to Telegram. If true, the name is displayed `Name:`. If false, it is displayed `Name`
 	 * @param settings.skipOldMessages Whether or not to skip through all previous messages cached from the telegram-side and start processing new messages ONLY
 	 * @param settings.sendEmojiWithStickers Whether or not to send the corresponding emoji when relaying stickers to Discord
-	 *
+	 * @param settings.filterCustomEmojis Determines what to do with custom emojis from Discord message before it reaches telegram
+	 * @param settings.replaceCustomEmojisWith Determines the string that will be used as a replacement for custom emojis
+	 * @param settings.replaceAtSign Whether or not to replace '@' sign to something else from Discord message before it reaches telegram
+	 * @param settings.replaceAtSignWith Determines the string that will be used as a replacement for '@' sign
+	 * @param settings.removeExcessiveSpacings Whether or not to remove excessive (2 or more) whitespaces from Discord message
 	 * @throws If the settings object does not validate
 	 */
 	constructor(settings: SettingProperties) {
@@ -48,6 +62,21 @@ export class TelegramSettings {
 
 		/** Whether or not to send the corresponding emoji when relaying stickers to Discord */
 		this.sendEmojiWithStickers = settings.sendEmojiWithStickers;
+
+		/** Determines what to do with custom emojis from Discord message before it reaches telegram */
+		this.filterCustomEmojis = settings.filterCustomEmojis;
+
+		/** Determines the string that will be used as a replacement for custom emojis */
+		this.replaceCustomEmojisWith = settings.replaceCustomEmojisWith;
+
+		/** Whether or not to replace '@' sign to something else from discord message before it reaches telegram */
+		this.replaceAtSign = settings.replaceAtSign;
+
+		/** Determines the string that will be used as a replacement for '@' sign */
+		this.replaceAtSignWith = settings.replaceAtSignWith;
+
+		/** Whether or not to remove excessive (2 or more) whitespaces from Discord message */
+		this.removeExcessiveSpacings = settings.removeExcessiveSpacings;
 	}
 
 	/** The bot token to use */
@@ -107,6 +136,27 @@ export class TelegramSettings {
 		if (Boolean(settings.sendEmojiWithStickers) !== settings.sendEmojiWithStickers) {
 			throw new Error("`settings.sendEmojiWithStickers` must be a boolean");
 		}
+
+		// Check that filterCustomEmojis is a string
+		if (typeof settings.filterCustomEmojis !== 'string') {
+			throw new Error("`settings.filterCustomEmojis` must be a string");
+		}
+		// Check that replaceCustomEmojisWith is a string
+		if (typeof settings.replaceCustomEmojisWith !== 'string') {
+			throw new Error("`settings.replaceCustomEmojisWith` must be a string");
+		}
+		// Check that replaceAtSign is a boolean
+		if (Boolean(settings.replaceAtSign) !== settings.replaceAtSign) {
+			throw new Error("`settings.replaceAtSign` must be a boolean");
+		}
+		// Check that replaceAtSignWith is a string
+		if (typeof settings.replaceAtSignWith !== 'string') {
+			throw new Error("`settings.replaceAtSignWith` must be a string");
+		}
+		// Check that removeExcessiveSpacings is a boolean
+		if (Boolean(settings.removeExcessiveSpacings) !== settings.removeExcessiveSpacings) {
+			throw new Error("`settings.removeExcessiveSpacings` must be a boolean");
+		}
 	}
 
 	/** Constant telling the Telegram token should be gotten from the environment */
@@ -121,7 +171,12 @@ export class TelegramSettings {
 			useFirstNameInsteadOfUsername: false,
 			colonAfterSenderName: false,
 			skipOldMessages: true,
-			sendEmojiWithStickers: true
+			sendEmojiWithStickers: true,
+			filterCustomEmojis: 'default',
+			replaceCustomEmojisWith: '🔹',
+			replaceAtSign: false,
+			replaceAtSignWith: '#',
+			removeExcessiveSpacings: false
 		};
 	}
 }


### PR DESCRIPTION
Reworked the way new helpers processed discord2telegram messages:

01. Removed removeNewlineSpaces helper and included check for whitespace following custom emoji to removeCustomEmojis helper instead.
02. Reworked filterCustomEmojis helper. It takes a string and has three states - default, remove and replace:
    * `default` - custom emojis will be transferred without any processing (ex: <:emojisnhead:1102667149627113602> My Text);
    * `remove` - custom emojis will be removed from the output (ex: My Text);
    * `replace` - custom emojis will be replaced with a definable string. Defined in `replaceCustomEmojisWith` (ex: 🔹 My Text).
03. Made all new helpers to be optional. 
04. Disabled all new helpers by default.
05. Cleanded up md2html.ts - doing nothing there in this version.
06. Updated README.md