### PR TITLE
Docker setup related improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/node_modules
+/dist
+settings.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:19-alpine
 
+RUN apk add --no-cache python3 g++ make
+
 WORKDIR /opt/TediCross/
 
 COPY . .
 
 RUN npm install --production
 
-# The node user (from node:16-alpine) has UID 1000, meaning most people with single-user systems will not have to change UID
-USER node
-
 VOLUME /opt/TediCross/data/
 
-ENTRYPOINT /usr/local/bin/npm start -- -c data/settings.yaml
+ENTRYPOINT /usr/local/bin/npm start
+CMD ["-c", "data/settings.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ RUN npm install --production
 
 VOLUME /opt/TediCross/data/
 
-ENTRYPOINT /usr/local/bin/npm start
-CMD ["-c", "data/settings.yaml"]
+ENTRYPOINT ["/usr/local/bin/npm"]
+CMD ["start", "--", "-c", "data/settings.yaml"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Setting up the bot requires basic knowledge of the command line, which is bash o
 
 Done! You now have a nice bridge between a Telegram chat and a Discord channel
 
+Running in Docker
+--------
+
+Please refer to [Docker Readme](./README-Docker.md) for the details.
+
 
 Settings
 --------


### PR DESCRIPTION
- Add `.gitignore` to prevent _settings.yaml_, _node_modules_ and _dist_ folders to be included in the image. 
If app was built on the host in the same dir it will keep context tiny and limited to src only, especially when host platform and build target require different dependencies (e.g. Docker on Mac)

- Use root user for max. compatibility. It might be better to leave this to the final user.

- Add python dependencies to the image for node-gyp rebuild. Lack of python was causing image build to fail on Raspberry Pi4 (ARM v7).

- Reference README-Docker.md in README

- ENTRYPOINT hold npm binary while CMD provide easy overridable args