### PR TITLE
fix: Message formatting breaks telegram > discord #340 | feat: new option "useEmbeds"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ jspm_packages
 
 # Project settings
 settings.yaml
+package-lock.json
 
 # Everything in the data directory
 data/
@@ -50,7 +51,6 @@ dist/
 
 # Lock files
 yarn.lock
-package-lock.json
 
 .vscode/
 /todo.txt

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ As mentioned in the step-by-step installation guide, there is a settings file. H
 	* `discord.relayLeaveMessages`: Whether to relay messages to Telegram about people leaving the Discord chat
 	* `discord.sendUsernames`: Whether to send the sender's name with the messages to Telegram
 	* `discord.crossDeleteOnTelegram`: Whether to also delete the corresponding message on Telegram when one is deleted in Discord
-    * `discord.useEmbeds`: Whether to use embeds for current bridge. Can be `always`, `never`, `auto`. Defaults to `false`
+        * `discord.useEmbeds`: Whether to use embeds for current bridge. Can be `always`, `never`, `auto`. Defaults to `false`
 	* `threadMap`: An array containing all threads mapping for each bridge
     	* `telegram`: Telegram thread ID. See step 13 on how to acquire it
     	* `discord`: Discord thread ID. See step 13 on how to acquire it

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ As mentioned in the step-by-step installation guide, there is a settings file. H
 	* `discord.relayLeaveMessages`: Whether to relay messages to Telegram about people leaving the Discord chat
 	* `discord.sendUsernames`: Whether to send the sender's name with the messages to Telegram
 	* `discord.crossDeleteOnTelegram`: Whether to also delete the corresponding message on Telegram when one is deleted in Discord
+    * `discord.useEmbeds`: Whether to use embeds for current bridge. Can be `always`, `never`, `auto`. Defaults to `false`
 	* `threadMap`: An array containing all threads mapping for each bridge
     	* `telegram`: Telegram thread ID. See step 13 on how to acquire it
     	* `discord`: Discord thread ID. See step 13 on how to acquire it

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ As mentioned in the step-by-step installation guide, there is a settings file. H
 	* `telegram.relayJoinMessages`: Whether to relay messages to Discord about people joining the Telegram chat
 	* `telegram.relayLeaveMessages`: Whether to relay messages to Discord about people leaving the Telegram chat
 	* `telegram.sendUsernames`: Whether to send the sender's name with the messages to Discord
-	* `telegram.relayCommands`: If set to `false`, messages starting with a `/` are not relayed to Discord
+	<!--* `telegram.relayCommands`: If set to `false`, messages starting with a `/` are not relayed to Discord-->
 	* `telegram.crossDeleteOnDiscord`: Whether to also delete the corresponding message on Discord when one is deleted on Telegram. **NOTE**: See FAQ about deleting messages.
 	* `discord.channelId`: ID of the channel the Discord end of the bridge is in. See step 11 on how to acquire it
 	* `discord.relayJoinMessages`: Whether to relay messages to Telegram about people joining the Discord chat

--- a/example.settings.yaml
+++ b/example.settings.yaml
@@ -33,7 +33,6 @@ bridges:
       relayJoinMessages: true
       relayLeaveMessages: true
       sendUsernames: true
-      relayCommands: true
       crossDeleteOnDiscord: true
     discord:
       channelId: 'DISCORD_CHANNEL_ID' # This ID must be wrapped in single quotes. Example: '244791815503347712'

--- a/example.settings.yaml
+++ b/example.settings.yaml
@@ -23,7 +23,8 @@ bridges:
   - name: First bridge
     direction: both
     threadMap: # Remove this and (telegram/discord pairs below if not planing to use Threads )
-      - telegram: TELEGRAM_THREAD_ID  # Threads have positive IDs
+      - name: First thread # optional naming for thread mapping
+        telegram: TELEGRAM_THREAD_ID  # Threads have positive IDs
         discord: 'DISCORD_THREAD_ID' # Discord thread IDs looks like other channel IDs
       - telegram: TELEGRAM_THREAD_ID  # Threads have positive IDs
         discord: 'DISCORD_THREAD_ID' # Discord thread IDs looks like other channel IDs
@@ -40,6 +41,7 @@ bridges:
       relayLeaveMessages: true
       sendUsernames: true
       crossDeleteOnTelegram: true
+      useEmbeds: 'auto' # always / never / auto
 debug: false
 messageTimeoutAmount: 24
 messageTimeoutUnit: 'hours' # This string must be a valid Moment time format. Example: seconds, minutes, hours, days, weeks, months, years

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tedicross",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tedicross",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18,6 +18,7 @@
         "@types/yargs": "^17.0.24",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
+        "cli-highlight": "^2.1.11",
         "discord.js": "^14.13.0",
         "eslint": "^8.47.0",
         "eslint-config-prettier": "^9.0.0",
@@ -908,6 +909,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1214,6 +1220,95 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/cli-highlight/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cliui": {
@@ -2084,6 +2179,14 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -2764,6 +2867,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3170,6 +3283,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -3938,6 +4069,25 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/titleize": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tedicross",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Bridging Telegram and Discord",
   "license": "MIT",
   "repository": {
@@ -24,6 +24,7 @@
     "@types/yargs": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
+    "cli-highlight": "^2.1.11",
     "discord.js": "^14.13.0",
     "eslint": "^8.47.0",
     "eslint-config-prettier": "^9.0.0",

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -33,6 +33,7 @@ export class Logger extends console.Console {
 	 *
 	 * @returns A function which works just like the given method, but also prints extra data
 	 */
+	// eslint-disable-next-line no-unused-vars, class-methods-use-this
 	_wrapper(method: (...args: any[]) => void, tag: string) {
 		return (...args: any[]) => {
 			// Create the stamp

--- a/src/MessageMap.ts
+++ b/src/MessageMap.ts
@@ -97,7 +97,7 @@ export class MessageMap {
 				toIds = await this._persistentMap.getCorresponding(direction, bridge, fromId);
 				// console.log("getCorresponding Return");
 				// console.log(toIds);
-				return toIds
+				return toIds;
 			}
 		} catch (err) {
 			// Unknown message ID. Don't do anything
@@ -127,7 +127,7 @@ export class MessageMap {
 				return fromId;
 			} else {
 				let fromId: string[] = [];
-				let key = await this._persistentMap.getCorrespondingReverse(bridge, toId);
+				const key = await this._persistentMap.getCorrespondingReverse(bridge, toId);
 				// console.log("getCorrespondingReverse Return");
 				// console.log(fromId);
 				if (key !== "0" && typeof key === "string") {
@@ -155,11 +155,14 @@ export class MessageMap {
 
 // Recursive Timeout to handle delays larger than the maximum value of 32-bit signed integers
 function safeTimeout(onTimeout: Function, delay: number) {
-	setTimeout(() => {
-		if (delay > MAX_32_BIT) {
-			return safeTimeout(onTimeout, delay - MAX_32_BIT);
-		} else {
-			onTimeout();
-		}
-	}, Math.min(MAX_32_BIT, delay));
+	setTimeout(
+		() => {
+			if (delay > MAX_32_BIT) {
+				return safeTimeout(onTimeout, delay - MAX_32_BIT);
+			} else {
+				onTimeout();
+			}
+		},
+		Math.min(MAX_32_BIT, delay)
+	);
 }

--- a/src/PersistentMessageMap.ts
+++ b/src/PersistentMessageMap.ts
@@ -1,9 +1,8 @@
 import fs from "fs";
 import { Logger } from "./Logger";
-import sqlite3 from 'sqlite3';
-import { Database, open } from 'sqlite';
+import sqlite3 from "sqlite3";
+import { Database, open } from "sqlite";
 import { Bridge } from "./bridgestuff/Bridge";
-import { forEach } from "ramda";
 type Direction = "d2t" | "t2d";
 
 /*************************************
@@ -31,7 +30,6 @@ export class PersistentMessageMap {
 		/** The path of the file this map is connected to */
 		this._filepath = filepath;
 
-
 		let dbExists = true;
 
 		try {
@@ -48,76 +46,95 @@ export class PersistentMessageMap {
 		});
 
 		if (!dbExists) {
-			this._db.then(async (db) => {
-				await db.exec('CREATE TABLE Bridges (pk INTEGER PRIMARY KEY AUTOINCREMENT, BridgeName TEXT)');
-				await db.exec('CREATE TABLE KeysToIds (pk INTEGER PRIMARY KEY AUTOINCREMENT, [Bridges.pk] INTEGER REFERENCES Bridges (pk), Keys TEXT)');
-				await db.exec('CREATE TABLE ToIds (pk INTEGER PRIMARY KEY AUTOINCREMENT, [KeysToIds.pk] INTEGER REFERENCES KeysToIds (pk), Ids TEXT)');
-			}).catch(err => this._logger.error("Error Creating Database", err));
+			this._db
+				.then(async db => {
+					await db.exec("CREATE TABLE Bridges (pk INTEGER PRIMARY KEY AUTOINCREMENT, BridgeName TEXT)");
+					await db.exec(
+						"CREATE TABLE KeysToIds (pk INTEGER PRIMARY KEY AUTOINCREMENT, [Bridges.pk] INTEGER REFERENCES Bridges (pk), Keys TEXT)"
+					);
+					await db.exec(
+						"CREATE TABLE ToIds (pk INTEGER PRIMARY KEY AUTOINCREMENT, [KeysToIds.pk] INTEGER REFERENCES KeysToIds (pk), Ids TEXT)"
+					);
+				})
+				.catch(err => this._logger.error("Error Creating Database", err));
 		}
 	}
 
 	insert(direction: Direction, bridge: Bridge, fromId: string, toId: string) {
-		this._db.then(async (db) => {
-			const bridgeCheck = await db.get("SELECT BridgeName FROM Bridges WHERE BridgeName = :sqlBridgeName",
-				{
-					':sqlBridgeName': bridge.name
+		this._db
+			.then(async db => {
+				const bridgeCheck = await db.get("SELECT BridgeName FROM Bridges WHERE BridgeName = :sqlBridgeName", {
+					":sqlBridgeName": bridge.name
 				});
-			if (bridgeCheck === undefined) {
-				await db.run("INSERT INTO Bridges (BridgeName) VALUES (:sqlBridgeName)",
-					{
-						':sqlBridgeName': bridge.name
+				if (bridgeCheck === undefined) {
+					await db.run("INSERT INTO Bridges (BridgeName) VALUES (:sqlBridgeName)", {
+						":sqlBridgeName": bridge.name
 					});
-			}
-			await db.run("INSERT INTO KeysToIds ([Bridges.pk], Keys) VALUES ((SELECT pk FROM Bridges WHERE BridgeName = :sqlBridgeName), :sqlKey)",
-				{
-					':sqlKey': `${direction} ${fromId}`,
-					':sqlBridgeName': bridge.name
-				});
-			await db.run("INSERT INTO ToIds ([KeysToIds.pk],Ids) VALUES ((SELECT pk FROM KeysToIds WHERE Keys = :sqlKey and [Bridges.pk] = (SELECT pk FROM Bridges WHERE BridgeName = :sqlBridgeName)),:sqlIds)",
-				{
-					':sqlIds': toId,
-					':sqlBridgeName': bridge.name,
-					':sqlKey': `${direction} ${fromId}`
-				});
-		}).catch(err => this._logger.error("Error Inserting into Database", err));
+				}
+				await db.run(
+					"INSERT INTO KeysToIds ([Bridges.pk], Keys) VALUES ((SELECT pk FROM Bridges WHERE BridgeName = :sqlBridgeName), :sqlKey)",
+					{
+						":sqlKey": `${direction} ${fromId}`,
+						":sqlBridgeName": bridge.name
+					}
+				);
+				await db.run(
+					"INSERT INTO ToIds ([KeysToIds.pk],Ids) VALUES ((SELECT pk FROM KeysToIds WHERE Keys = :sqlKey and [Bridges.pk] = (SELECT pk FROM Bridges WHERE BridgeName = :sqlBridgeName)),:sqlIds)",
+					{
+						":sqlIds": toId,
+						":sqlBridgeName": bridge.name,
+						":sqlKey": `${direction} ${fromId}`
+					}
+				);
+			})
+			.catch(err => this._logger.error("Error Inserting into Database", err));
 	}
 
 	async getCorresponding(direction: Direction, bridge: Bridge, fromId: string) {
-		let toId: string[] = [];
-		const results = await this._db.then(async (db) => {
-
-			const result = await db.all('SELECT Ids FROM ToIds WHERE [KeysToIds.pk] = (SELECT pk FROM KeysToIds WHERE Keys = :sqlKey and [Bridges.pk] = (SELECT pk FROM Bridges WHERE BridgeName = :sqlBridgeName))',
-				{
-					':sqlKey': `${direction} ${fromId}`,
-					':sqlBridgeName': bridge.name
-				});
-			return result;
-		}).catch(err => this._logger.error("Error getting Corresponding from Database", err));
+		const toId: string[] = [];
+		const results = await this._db
+			.then(async db => {
+				const result = await db.all(
+					"SELECT Ids FROM ToIds WHERE [KeysToIds.pk] = (SELECT pk FROM KeysToIds WHERE Keys = :sqlKey and [Bridges.pk] = (SELECT pk FROM Bridges WHERE BridgeName = :sqlBridgeName))",
+					{
+						":sqlKey": `${direction} ${fromId}`,
+						":sqlBridgeName": bridge.name
+					}
+				);
+				return result;
+			})
+			.catch(err => this._logger.error("Error getting Corresponding from Database", err));
 		if (results !== undefined) {
-			results.forEach((id) => { toId.push(id.Ids); });
+			results.forEach(id => {
+				toId.push(id.Ids);
+			});
 		}
-		 //this._logger.log("getCorresponding for: " + bridge.name + " " + direction + " " + fromId);
-		 //this._logger.log(results);
-		 //this._logger.log(toId);
+		//this._logger.log("getCorresponding for: " + bridge.name + " " + direction + " " + fromId);
+		//this._logger.log(results);
+		//this._logger.log(toId);
 		return toId;
 	}
 
 	async getCorrespondingReverse(bridge: Bridge, toId: string) {
 		let fromId = "";
-		const results = await this._db.then(async (db) => {
-			const result = await db.get('SELECT Keys FROM KeysToIds WHERE [Bridges.pk] = (SELECT pk FROM Bridges WHERE BridgeName = :sqlBridgeName) AND pk = (SELECT [KeysToIds.pk] FROM ToIds WHERE Ids = :sqlIds)',
-				{
-					':sqlBridgeName': bridge.name,
-					':sqlIds': toId
-				});
-			return result;
-		}).catch(err => this._logger.error("Error getting Corresponding Reverse from Database", err));
+		const results = await this._db
+			.then(async db => {
+				const result = await db.get(
+					"SELECT Keys FROM KeysToIds WHERE [Bridges.pk] = (SELECT pk FROM Bridges WHERE BridgeName = :sqlBridgeName) AND pk = (SELECT [KeysToIds.pk] FROM ToIds WHERE Ids = :sqlIds)",
+					{
+						":sqlBridgeName": bridge.name,
+						":sqlIds": toId
+					}
+				);
+				return result;
+			})
+			.catch(err => this._logger.error("Error getting Corresponding Reverse from Database", err));
 		if (results !== undefined) {
 			fromId = results.Keys;
 		}
-		 //this._logger.log("getCorrespondingReverse for: " + bridge.name + " " + toId);
-		 //this._logger.log(results);
-		 //this._logger.log(fromId);
+		//this._logger.log("getCorrespondingReverse for: " + bridge.name + " " + toId);
+		//this._logger.log(results);
+		//this._logger.log(fromId);
 		return fromId;
 	}
 }

--- a/src/bridgestuff/BridgeSettingsDiscord.ts
+++ b/src/bridgestuff/BridgeSettingsDiscord.ts
@@ -4,6 +4,7 @@ export interface BridgeSettingsDiscordProperties {
 	relayJoinMessages: boolean;
 	relayLeaveMessages: boolean;
 	crossDeleteOnTelegram: boolean;
+	useEmbeds: string;
 	serverId?: string;
 }
 
@@ -14,6 +15,7 @@ export class BridgeSettingsDiscord {
 	public relayJoinMessages: boolean;
 	public relayLeaveMessages: boolean;
 	public crossDeleteOnTelegram: boolean;
+	public useEmbeds: string;
 
 	/**
 	 * Creates a new BridgeSettingsDiscord object
@@ -42,6 +44,9 @@ export class BridgeSettingsDiscord {
 
 		/** Whether or not to delete messages on Telegram when a message is deleted on Discord */
 		this.crossDeleteOnTelegram = settings.crossDeleteOnTelegram;
+
+		/** Whether to use Embeds when posting on Discord */
+		this.useEmbeds = settings.useEmbeds;
 	}
 
 	/**

--- a/src/bridgestuff/BridgeSettingsTelegram.ts
+++ b/src/bridgestuff/BridgeSettingsTelegram.ts
@@ -1,7 +1,7 @@
 export interface BridgeSettingsTelegramProperties {
 	chatId: number;
 	sendUsernames: boolean;
-	relayCommands: boolean;
+	//relayCommands: boolean;
 	relayJoinMessages: boolean;
 	relayLeaveMessages: boolean;
 	crossDeleteOnDiscord: boolean;
@@ -15,7 +15,7 @@ export class BridgeSettingsTelegram {
 	public relayJoinMessages: boolean;
 	public relayLeaveMessages: boolean;
 	public crossDeleteOnDiscord: boolean;
-	public relayCommands: boolean;
+	//public relayCommands: boolean;
 
 	/**
 	 * Creates a new BridgeSettingsTelegram object
@@ -42,7 +42,7 @@ export class BridgeSettingsTelegram {
 		this.sendUsernames = settings.sendUsernames;
 
 		/** Whether or not to relay messages starting with "/" (commands) */
-		this.relayCommands = settings.relayCommands;
+		//this.relayCommands = settings.relayCommands;
 
 		/** Whether or not to delete messages when they are edited to be a single dot */
 		this.crossDeleteOnDiscord = settings.crossDeleteOnDiscord;
@@ -72,9 +72,9 @@ export class BridgeSettingsTelegram {
 		}
 
 		// Check that relayCommands is a boolean
-		if (Boolean(settings.relayCommands) !== settings.relayCommands) {
+		/*if (Boolean(settings.relayCommands) !== settings.relayCommands) {
 			throw new Error("`settings.relayCommands` must be a boolean");
-		}
+		}*/
 
 		// Check that crossDeleteOnDiscord is a boolean
 		if (Boolean(settings.crossDeleteOnDiscord) !== settings.crossDeleteOnDiscord) {

--- a/src/discord2telegram/md2html.ts
+++ b/src/discord2telegram/md2html.ts
@@ -87,16 +87,18 @@ const spoilerRule = {
 };
 
 const rules = _.extend({}, simpleMarkdown.defaultRules, {
-	spoiler: spoilerRule
-});
+	// Ignore some rules which only creates trouble
+	list: Object.assign({}, simpleMarkdown.defaultRules.list, {
+		// order: Number.POSITIVE_INFINITY,
+		match: () => null
+	}),
 
-// Ignore some rules which only creates trouble
-["list", "heading"].forEach(type => {
-	//@ts-ignore TODO: As per the documentation the defaultRules are only allowed to be read, not written, check for alternative way.
-	simpleMarkdown.defaultRules[type] = {
-		order: Number.POSITIVE_INFINITY,
-		match: () => null // Never match anything in order to ignore this rule
-	};
+	heading: Object.assign({}, simpleMarkdown.defaultRules.heading, {
+		// order: Number.POSITIVE_INFINITY,
+		match: () => null
+	}),
+
+	spoiler: spoilerRule
 });
 
 const rawBuiltParser = simpleMarkdown.parserFor(rules);
@@ -133,6 +135,7 @@ export function md2html(text: string, settings: TelegramSettings) {
 		.map(rootNode => {
 			// Do some node preprocessing
 			let content = rootNode; // Default to just keeping the node
+
 			if (rootNode.type === "paragraph") {
 				// Remove the outer paragraph, if one exists
 				content = rootNode.content;
@@ -148,6 +151,8 @@ export function md2html(text: string, settings: TelegramSettings) {
 				return html + "\n";
 			} else if (node.type === "hr") {
 				return html + "---";
+			} else if (node.type === "link") {
+				return html + `<a href='${node.target}'>${extractText(node)}</a>`;
 			}
 
 			// Turn the nodes into HTML

--- a/src/settings/DiscordSettings.ts
+++ b/src/settings/DiscordSettings.ts
@@ -7,6 +7,7 @@ interface Settings {
 	suppressThisIsPrivateBotMessage: boolean;
 	enableCustomStatus: boolean;
 	customStatusMessage: string;
+	useEmbeds: string;
 }
 
 /*****************************
@@ -27,6 +28,7 @@ export class DiscordSettings {
 	suppressThisIsPrivateBotMessage: boolean;
 	enableCustomStatus: boolean;
 	customStatusMessage: string;
+	useEmbeds: string;
 
 	/**
 	 * Creates a new DiscordSettings object
@@ -62,6 +64,9 @@ export class DiscordSettings {
 
 		/** The playing status message */
 		this.customStatusMessage = settings.customStatusMessage;
+
+		/** Whether to use embeds */
+		this.useEmbeds = settings.useEmbeds;
 	}
 
 	/** The bot token to use */
@@ -126,6 +131,11 @@ export class DiscordSettings {
 		if (typeof settings.customStatusMessage !== "string") {
 			throw new Error("`settings.customStatusMessage` must be a string");
 		}
+
+		// Check that the useEmbeds is a string
+		if (typeof settings.useEmbeds !== "string") {
+			throw new Error("`settings.useEmbeds` must be a string");
+		}
 	}
 
 	/** Constant telling the Discord token should be gotten from the environment */
@@ -141,7 +151,8 @@ export class DiscordSettings {
 			useNickname: false,
 			suppressThisIsPrivateBotMessage: false,
 			enableCustomStatus: false,
-			customStatusMessage: "TediCross"
+			customStatusMessage: "TediCross",
+			useEmbeds: "auto"
 		};
 	}
 }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -191,12 +191,12 @@ export class Settings {
 		const settings = R.clone(rawSettings);
 
 		// 2019-11-08: Turn `ignoreCommands` into `relayCommands`, as `ignoreCommands` accidently did the opposite of what it was supposed to do
-		for (const bridge of settings.bridges) {
+		/*for (const bridge of settings.bridges) {
 			if (R.isNil(bridge.telegram.relayCommands)) {
 				bridge.telegram.relayCommands = bridge.telegram.ignoreCommands!;
 			}
 			delete bridge.telegram.ignoreCommands;
-		}
+		}*/
 
 		// 2019-11-08: Remove the `serverId` setting from the discord part of the bridges
 		for (const bridge of settings.bridges) {

--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -20,4 +20,3 @@ export const sleep = util.promisify(setTimeout);
  * @returns Promise resolving after one minute
  */
 export const sleepOneMinute = R.partial(sleep, [moment.duration(1, "minute").asMilliseconds()]);
-

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -347,6 +347,7 @@ export const handleEdits = createMessageHandler(async (ctx: TediCrossContext, br
 		try {
 			const tgMessage = ctx.tediCross.message;
 
+
 			// Wait for the Discord bot to become ready
 			await ctx.TediCross.dcBot.ready;
 
@@ -356,11 +357,10 @@ export const handleEdits = createMessageHandler(async (ctx: TediCrossContext, br
 				bridge,
 				tgMessage.message_id
 			);
-			//console.log("t2d edit getCorresponding: " + dcMessageId);
 
 			// Get the messages from Discord
-			const dcMessage = await fetchDiscordChannel(ctx.TediCross.dcBot, bridge).then(channel =>
-				channel.messages.fetch(dcMessageId)
+			const dcMessage = await fetchDiscordChannel(ctx.TediCross.dcBot, bridge, tgMessage.message_thread_id).then(
+				channel => channel.messages.fetch(dcMessageId)
 			);
 
 			R.forEach(async (prepared: any) => {

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -256,37 +256,104 @@ export const relayMessage = (ctx: TediCrossContext) => {
 
 			const messageText = prepared.header + "\n" + prepared.text;
 
-			// NOTE: using EMBED when over 2000 symbols length
-
 			const sendObject: DiscordMessage = {};
-			if (messageText.length > 2000 || prepared.hasLinks) {
-				const text = prepared.text.length > 4096 ? prepared.text.substring(0, 4090) + "..." : prepared.text;
-				const embed = new EmbedBuilder().setTitle(prepared.header).setDescription(text);
-				sendObject.embeds = [embed];
-			} else {
-				sendObject.content = messageText;
-			}
 
-			if (!R.isNil(prepared.file)) {
-				sendObject.files = prepared.files || [prepared.file];
-			}
+			const useEmbeds =
+				(messageText.length > 2000 && prepared.bridge.discord.useEmbeds !== "never") || prepared.hasLinks;
 
-			// console.log(`messageToReply: ${messageToReply}`);
-			// console.log(`replyId: ${replyId}`);
-
-			try {
-				if (replyId === "0" || replyId === undefined || messageToReply === undefined) {
-					dcMessage = await channel.send(sendObject);
-				} else {
-					dcMessage = await messageToReply.reply(sendObject);
+			if (useEmbeds) {
+				const text = prepared.text.length > 4096 ? prepared.text.substring(0, 4090) + "..." : prepared.text || ' ';
+				let embeds: EmbedBuilder[] = [];
+				const photoEmbeds: EmbedBuilder[] = [];
+				// build text embed
+				embeds.push(new EmbedBuilder().setTitle(prepared.header).setDescription(text));
+				// process attached files
+				if (!R.isNil(prepared.file)) {
+					const files = prepared.files || [prepared.file];
+					let resFiles = [];
+					let tempPhotoUrl: string = "";
+					for (const file of files) {
+						// only photo attachments can be used as embeds
+						if (file.description === "photo") {
+							tempPhotoUrl = file.attachment;
+							photoEmbeds.push(new EmbedBuilder().setImage(tempPhotoUrl));
+						} else {
+							resFiles.push(file);
+						}
+					}
+					// if only 1 photo - set it into Embed
+					if (photoEmbeds.length === 1) {
+						embeds[0].setImage(tempPhotoUrl);
+					} else {
+						// if useEmbeds = always - add photos as embeds one by one
+						if (prepared.bridge.discord.useEmbeds !== "auto") {
+							embeds = embeds.concat(photoEmbeds);
+						} else {
+							resFiles = files;
+						}
+					}
+					if (resFiles.length) {
+						sendObject.files = resFiles;
+					}
 				}
-			} catch (err: any) {
-				if (err.message === "Request entity too large") {
-					dcMessage = await channel.send(
-						`***${prepared.senderName}** on Telegram sent a file, but it was too large for Discord. If you want it, ask them to send it some other way*`
+
+				sendObject.embeds = embeds;
+
+				// trying to send prepared message
+				try {
+					if (replyId === "0" || replyId === undefined || messageToReply === undefined) {
+						dcMessage = await channel.send(sendObject);
+					} else {
+						dcMessage = await messageToReply.reply(sendObject);
+					}
+				} catch (err: any) {
+					if (err.message === "Request entity too large") {
+						dcMessage = await channel.send(
+							`***${prepared.senderName}** on Telegram sent a file, but it was too large for Discord. If you want it, ask them to send it some other way*`
+						);
+					} else {
+						throw err;
+					}
+				}
+			} else {
+				// old text split version when user don't want to use embeds
+				let chunks = R.splitEvery(2000, messageText);
+				if (!R.isNil(prepared.file)) {
+					try {
+						if (replyId === "0" || replyId === undefined || messageToReply === undefined) {
+							dcMessage = await channel.send({
+								content: R.head(chunks),
+								files: prepared.files || [prepared.file]
+							});
+						} else {
+							dcMessage = await messageToReply.reply({
+								content: R.head(chunks),
+								files: prepared.files || [prepared.file]
+							});
+						}
+						chunks = R.tail(chunks);
+					} catch (err: any) {
+						if (err.message === "Request entity too large") {
+							dcMessage = await channel.send(
+								`***${prepared.senderName}** on Telegram sent a file, but it was too large for Discord. If you want it, ask them to send it some other way*`
+							);
+						} else {
+							throw err;
+						}
+					}
+				}
+				if (replyId === "0" || replyId === undefined || messageToReply === undefined) {
+					dcMessage = await R.reduce(
+						(p, chunk) => p.then(() => channel.send(chunk)),
+						Promise.resolve(dcMessage),
+						chunks
 					);
 				} else {
-					throw err;
+					dcMessage = await R.reduce(
+						(p, chunk) => p.then(() => messageToReply.reply(chunk)),
+						Promise.resolve(dcMessage),
+						chunks
+					);
 				}
 			}
 
@@ -346,7 +413,6 @@ export const handleEdits = createMessageHandler(async (ctx: TediCrossContext, br
 	const edit = async (ctx: TediCrossContext, bridge: any) => {
 		try {
 			const tgMessage = ctx.tediCross.message;
-
 
 			// Wait for the Discord bot to become ready
 			await ctx.TediCross.dcBot.ready;

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -172,7 +172,7 @@ export const leftChatMember = createMessageHandler((ctx: TediCrossContext, bridg
 });
 
 const parseMediaGroup = (ctx: TediCrossContext, byTimer: boolean = false) => {
-	// ctx.TediCross.logger.info(ctx.tediCross.message.media_group_id, byTimer);
+	//ctx.TediCross.logger.info(ctx.tediCross.message.media_group_id, byTimer);
 
 	const groupIdMap = ctx.TediCross.groupIdMap;
 	const groupId = ctx.tediCross.message.media_group_id;
@@ -182,7 +182,7 @@ const parseMediaGroup = (ctx: TediCrossContext, byTimer: boolean = false) => {
 			const ctxArray = groupIdMap.get(groupId);
 			groupIdMap.delete(groupId);
 			if (ctxArray) {
-				// ctx.TediCross.logger.info(`Array Length: ${ctxArray.length}`);
+				//ctx.TediCross.logger.info(`Array Length: ${ctxArray.length}`);
 				const comboCtx: TediCrossContext = ctxArray[0];
 				comboCtx.tediCross.hasMediaGroup = true;
 				const prepared = comboCtx.tediCross.prepared[0];
@@ -204,12 +204,12 @@ const parseMediaGroup = (ctx: TediCrossContext, byTimer: boolean = false) => {
 					}
 				}
 
-				// ctx.TediCross.logger.info(`Files Array Length: ${prepared.files.length}`);
+				//ctx.TediCross.logger.info(`Files Array Length: ${prepared.files.length}`);
 
 				relayMessage(comboCtx);
 			}
 		} else {
-			// ctx.TediCross.logger.info(`No groupId: ${groupId}`);
+			//ctx.TediCross.logger.info(`No groupId: ${groupId}`);
 			return;
 		}
 	} else {
@@ -255,14 +255,14 @@ export const relayMessage = (ctx: TediCrossContext) => {
 			const replyId = prepared.replyId;
 
 			const messageText = prepared.header + "\n" + prepared.text;
-
 			const sendObject: DiscordMessage = {};
 
 			const useEmbeds =
 				(messageText.length > 2000 && prepared.bridge.discord.useEmbeds !== "never") || prepared.hasLinks;
 
 			if (useEmbeds) {
-				const text = prepared.text.length > 4096 ? prepared.text.substring(0, 4090) + "..." : prepared.text || ' ';
+				const text =
+					prepared.text.length > 4096 ? prepared.text.substring(0, 4090) + "..." : prepared.text || " ";
 				let embeds: EmbedBuilder[] = [];
 				const photoEmbeds: EmbedBuilder[] = [];
 				// build text embed

--- a/src/telegram2discord/handleEntities.ts
+++ b/src/telegram2discord/handleEntities.ts
@@ -38,11 +38,17 @@ export async function handleEntities(text: string, entities: MessageEntity[], dc
 		entities = [];
 	}
 
+	// map for tracking overlapping entities
+	const offsetMap: Set<number> = new Set();
 	// Iterate over the entities backwards, to not fuck up the offset
 	for (let i = entities.length - 1; i >= 0; i--) {
 		// Select the entity object
 		const e = entities[i];
 
+		// NOTE: trying to skip overlapping entities
+		// TODO: need to check whole intersection length not only beginning...
+		if (offsetMap.has(e.offset)) continue;
+		offsetMap.add(e.offset);
 		// Extract the entity part
 		const part = text.substring(e.offset, e.offset + e.length);
 

--- a/src/telegram2discord/middlewares.ts
+++ b/src/telegram2discord/middlewares.ts
@@ -517,6 +517,9 @@ function addFileLink(ctx: TediCrossContext, next: () => void) {
 			if (!R.isNil(ctx.tediCross.file)) {
 				return ctx.telegram.getFileLink(ctx.tediCross.file.id).then(fileLink => {
 					ctx.tediCross.file.link = fileLink.href;
+					if (ctx.tediCross.file.type === "photo") {
+						ctx.tediCross.file.name = fileLink.href.split("/").pop() || ctx.tediCross.file.name;
+					}
 				});
 			}
 		})
@@ -675,7 +678,7 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 				R.compose(R.isNil, R.prop("file")),
 				R.always(undefined),
 				(tc: TediCrossContext["TediCross"]["tc"]) =>
-					new Discord.AttachmentBuilder(tc.file.link, { name: tc.file.name })
+					new Discord.AttachmentBuilder(tc.file.link, { name: tc.file.name, description: tc.file.type })
 			)(tc);
 
 			// Make the text to send

--- a/src/telegram2discord/middlewares.ts
+++ b/src/telegram2discord/middlewares.ts
@@ -156,7 +156,6 @@ function addTediCrossObj(ctx: TediCrossContext, next: () => void) {
  */
 function addMessageObj(ctx: TediCrossContext, next: () => void) {
 	// Put it on the context
-
 	// bypass pinned message notification
 	if (
 		(ctx as any).update.message &&
@@ -192,7 +191,7 @@ function addMessageId(ctx: TediCrossContext, next: () => void) {
 
 		next();
 	} else {
-		// console.error("Unsupported telegram message type");
+		console.error("Unsupported telegram message type");
 	}
 }
 
@@ -207,6 +206,7 @@ function addMessageId(ctx: TediCrossContext, next: () => void) {
  */
 function addBridgesToContext(ctx: TediCrossContext, next: () => void) {
 	ctx.tediCross.bridges = ctx.TediCross.bridgeMap.fromTelegramChatId(ctx.tediCross.message.chat.id);
+
 	next();
 }
 
@@ -226,6 +226,7 @@ function removeD2TBridges(ctx: TediCrossContext, next: () => void) {
 	next();
 }
 
+// THIS BREAKS THE BOT
 /**
  * Removes bridges with the `relayCommands` flag set to false from the bridge list
  *
@@ -293,8 +294,8 @@ function informThisIsPrivateBot(ctx: TediCrossContext, next: () => void) {
 				if (!ctx.TediCross.settings.telegram.suppressThisIsPrivateBotMessage) {
 					ctx.reply(
 						"This is an instance of a [TediCross](https://github.com/TediCross/TediCross) bot, " +
-						"bridging a chat in Telegram with one in Discord. " +
-						"If you wish to use TediCross yourself, please download and create an instance.",
+							"bridging a chat in Telegram with one in Discord. " +
+							"If you wish to use TediCross yourself, please download and create an instance.",
 						{ parse_mode: "Markdown" }
 					)
 						.then(msg =>
@@ -347,8 +348,8 @@ function addReplyObj(ctx: TediCrossContext, next: () => void) {
 		? ctx.tediCross.message?.message_thread_id !== ctx.tediCross.message?.reply_to_message?.message_id
 			? ctx.tediCross.message?.reply_to_message
 			: ctx.tediCross.message?.reply_to_message?.message_thread_id
-				? undefined
-				: ctx.tediCross.message?.reply_to_message
+			? undefined
+			: ctx.tediCross.message?.reply_to_message
 		: ctx.tediCross.message?.reply_to_message;
 
 	// console.log(`repliedToMessage: ${repliedToMessage}`);
@@ -429,7 +430,6 @@ function addForwardFrom(ctx: TediCrossContext, next: () => void) {
  */
 function addTextObj(ctx: TediCrossContext, next: () => void) {
 	const text = createTextObjFromMessage(ctx, ctx.tediCross.message as any);
-
 	if (!R.isNil(text)) {
 		ctx.tediCross.text = text;
 	}
@@ -560,8 +560,8 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 				? ctx.tediCross.message?.message_thread_id !== ctx.tediCross.message?.reply_to_message?.message_id
 					? ctx.tediCross.message?.reply_to_message
 					: ctx.tediCross.message?.reply_to_message?.message_thread_id
-						? undefined
-						: ctx.tediCross.message?.reply_to_message
+					? undefined
+					: ctx.tediCross.message?.reply_to_message
 				: ctx.tediCross.message?.reply_to_message;
 
 			if (typeof messageReference !== "undefined") {
@@ -613,19 +613,19 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 				const repliedToName = R.isNil(tc.replyTo)
 					? null
 					: await R.ifElse(
-						R.prop("isReplyToTediCross") as any,
-						R.compose(
-							(username: string) => makeDiscordMention(username, ctx.TediCross.dcBot, bridge),
-							R.prop("dcUsername") as any
-						),
-						R.compose(
-							R.partial(makeDisplayName, [
-								ctx.TediCross.settings.telegram.useFirstNameInsteadOfUsername
-							]),
-							//@ts-ignore
-							R.prop("originalFrom")
-						)
-					)(tc.replyTo);
+							R.prop("isReplyToTediCross") as any,
+							R.compose(
+								(username: string) => makeDiscordMention(username, ctx.TediCross.dcBot, bridge),
+								R.prop("dcUsername") as any
+							),
+							R.compose(
+								R.partial(makeDisplayName, [
+									ctx.TediCross.settings.telegram.useFirstNameInsteadOfUsername
+								]),
+								//@ts-ignore
+								R.prop("originalFrom")
+							)
+					  )(tc.replyTo);
 				// Build the header
 				let header: string;
 				if (bridge.telegram.sendUsernames) {
@@ -683,13 +683,19 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 
 			// Make the text to send
 			const [text, hasLinks] = await (async () => {
-				let [text, hasLinks] = await handleEntities(tc.text.raw, tc.text.entities, ctx.TediCross.dcBot, bridge);
+				const [text, hasLinks] = await handleEntities(
+					tc.text.raw,
+					tc.text.entities,
+					ctx.TediCross.dcBot,
+					bridge
+				);
+				let editableText = text;
 
 				if (!R.isNil(replyQuote) && !tc.hasActualReference) {
-					text = replyQuote + "\n" + text;
+					editableText = replyQuote + "\n" + editableText;
 				}
 
-				return [text, hasLinks];
+				return [editableText, hasLinks];
 			})();
 
 			return {

--- a/src/telegram2discord/middlewares.ts
+++ b/src/telegram2discord/middlewares.ts
@@ -293,8 +293,8 @@ function informThisIsPrivateBot(ctx: TediCrossContext, next: () => void) {
 				if (!ctx.TediCross.settings.telegram.suppressThisIsPrivateBotMessage) {
 					ctx.reply(
 						"This is an instance of a [TediCross](https://github.com/TediCross/TediCross) bot, " +
-							"bridging a chat in Telegram with one in Discord. " +
-							"If you wish to use TediCross yourself, please download and create an instance.",
+						"bridging a chat in Telegram with one in Discord. " +
+						"If you wish to use TediCross yourself, please download and create an instance.",
 						{ parse_mode: "Markdown" }
 					)
 						.then(msg =>
@@ -347,8 +347,8 @@ function addReplyObj(ctx: TediCrossContext, next: () => void) {
 		? ctx.tediCross.message?.message_thread_id !== ctx.tediCross.message?.reply_to_message?.message_id
 			? ctx.tediCross.message?.reply_to_message
 			: ctx.tediCross.message?.reply_to_message?.message_thread_id
-			? undefined
-			: ctx.tediCross.message?.reply_to_message
+				? undefined
+				: ctx.tediCross.message?.reply_to_message
 		: ctx.tediCross.message?.reply_to_message;
 
 	// console.log(`repliedToMessage: ${repliedToMessage}`);
@@ -557,8 +557,8 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 				? ctx.tediCross.message?.message_thread_id !== ctx.tediCross.message?.reply_to_message?.message_id
 					? ctx.tediCross.message?.reply_to_message
 					: ctx.tediCross.message?.reply_to_message?.message_thread_id
-					? undefined
-					: ctx.tediCross.message?.reply_to_message
+						? undefined
+						: ctx.tediCross.message?.reply_to_message
 				: ctx.tediCross.message?.reply_to_message;
 
 			if (typeof messageReference !== "undefined") {
@@ -610,19 +610,19 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 				const repliedToName = R.isNil(tc.replyTo)
 					? null
 					: await R.ifElse(
-							R.prop("isReplyToTediCross") as any,
-							R.compose(
-								(username: string) => makeDiscordMention(username, ctx.TediCross.dcBot, bridge),
-								R.prop("dcUsername") as any
-							),
-							R.compose(
-								R.partial(makeDisplayName, [
-									ctx.TediCross.settings.telegram.useFirstNameInsteadOfUsername
-								]),
-								//@ts-ignore
-								R.prop("originalFrom")
-							)
-					  )(tc.replyTo);
+						R.prop("isReplyToTediCross") as any,
+						R.compose(
+							(username: string) => makeDiscordMention(username, ctx.TediCross.dcBot, bridge),
+							R.prop("dcUsername") as any
+						),
+						R.compose(
+							R.partial(makeDisplayName, [
+								ctx.TediCross.settings.telegram.useFirstNameInsteadOfUsername
+							]),
+							//@ts-ignore
+							R.prop("originalFrom")
+						)
+					)(tc.replyTo);
 				// Build the header
 				let header: string;
 				if (bridge.telegram.sendUsernames) {

--- a/src/telegram2discord/setup.ts
+++ b/src/telegram2discord/setup.ts
@@ -130,6 +130,8 @@ export function setup(
 			tgBot.use(middlewares.addBridgesToContext);
 			tgBot.use(middlewares.informThisIsPrivateBot);
 			tgBot.use(middlewares.removeD2TBridges);
+			//@ts-ignore telegram expacts a second parameter
+			//tgBot.command(middlewares.removeBridgesIgnoringCommands);
 			tgBot.on("new_chat_members", middlewares.removeBridgesIgnoringJoinMessages);
 			tgBot.on("left_chat_member", middlewares.removeBridgesIgnoringLeaveMessages);
 			tgBot.on("new_chat_members", newChatMembers);
@@ -148,7 +150,6 @@ export function setup(
 
 			// Don't crash on errors
 			tgBot.catch((err: any) => {
-				console.log(err);
 				// The docs says timeout errors should always be rethrown
 				// @ts-ignore TODO: Telefraf does not exprt the TimoutError, alternative implementation needed
 				if (err instanceof telegraf.TimeoutError) {

--- a/src/telegram2discord/setup.ts
+++ b/src/telegram2discord/setup.ts
@@ -130,8 +130,6 @@ export function setup(
 			tgBot.use(middlewares.addBridgesToContext);
 			tgBot.use(middlewares.informThisIsPrivateBot);
 			tgBot.use(middlewares.removeD2TBridges);
-			//@ts-ignore telegram expacts a second parameter
-			tgBot.command(middlewares.removeBridgesIgnoringCommands);
 			tgBot.on("new_chat_members", middlewares.removeBridgesIgnoringJoinMessages);
 			tgBot.on("left_chat_member", middlewares.removeBridgesIgnoringLeaveMessages);
 			tgBot.on("new_chat_members", newChatMembers);
@@ -150,6 +148,7 @@ export function setup(
 
 			// Don't crash on errors
 			tgBot.catch((err: any) => {
+				console.log(err);
 				// The docs says timeout errors should always be rethrown
 				// @ts-ignore TODO: Telefraf does not exprt the TimoutError, alternative implementation needed
 				if (err instanceof telegraf.TimeoutError) {


### PR DESCRIPTION
1. Full fix for #340 (When some entity in Telegram has double(triple...) formatting - parser cuts off part of source message)
2. Fix: Message edits in telegram thread were not transferred
3. Added bridge option "useEmbeds" to define embed usage (always / never / auto)