### PR TITLE
Fix #346

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ As mentioned in the step-by-step installation guide, there is a settings file. H
 	* `discord.sendUsernames`: Whether to send the sender's name with the messages to Telegram
 	* `discord.crossDeleteOnTelegram`: Whether to also delete the corresponding message on Telegram when one is deleted in Discord
 	* `discord.disableWebPreviewOnTelegram`: Whether to disable links preview when relaying to Telegram
-    * `discord.useEmbeds`: Whether to use embeds for current bridge. Can be `always`, `never`, `auto`. Defaults to `false`
+	* `discord.useEmbeds`: Whether to use embeds for current bridge. Can be `always`, `never`, `auto`. Defaults to `false`
 	* `threadMap`: An array containing all threads mapping for each bridge
-    	* `telegram`: Telegram thread ID. See step 13 on how to acquire it
-    	* `discord`: Discord thread ID. See step 13 on how to acquire it
+		* `telegram`: Telegram thread ID. See step 13 on how to acquire it
+		* `discord`: Discord thread ID. See step 13 on how to acquire it
 
 The available settings will occasionally change. The bot takes care of this automatically
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ As mentioned in the step-by-step installation guide, there is a settings file. H
 	* `discord.relayLeaveMessages`: Whether to relay messages to Telegram about people leaving the Discord chat
 	* `discord.sendUsernames`: Whether to send the sender's name with the messages to Telegram
 	* `discord.crossDeleteOnTelegram`: Whether to also delete the corresponding message on Telegram when one is deleted in Discord
-        * `discord.useEmbeds`: Whether to use embeds for current bridge. Can be `always`, `never`, `auto`. Defaults to `false`
+	* `discord.disableWebPreviewOnTelegram`: Whether to disable links preview when relaying to Telegram
+    * `discord.useEmbeds`: Whether to use embeds for current bridge. Can be `always`, `never`, `auto`. Defaults to `false`
 	* `threadMap`: An array containing all threads mapping for each bridge
     	* `telegram`: Telegram thread ID. See step 13 on how to acquire it
     	* `discord`: Discord thread ID. See step 13 on how to acquire it

--- a/example.settings.yaml
+++ b/example.settings.yaml
@@ -40,6 +40,7 @@ bridges:
       relayLeaveMessages: true
       sendUsernames: true
       crossDeleteOnTelegram: true
+      disableWebPreviewOnTelegram: false
       useEmbeds: 'auto' # always / never / auto
 debug: false
 messageTimeoutAmount: 24

--- a/src/bridgestuff/BridgeSettingsDiscord.ts
+++ b/src/bridgestuff/BridgeSettingsDiscord.ts
@@ -4,6 +4,7 @@ export interface BridgeSettingsDiscordProperties {
 	relayJoinMessages: boolean;
 	relayLeaveMessages: boolean;
 	crossDeleteOnTelegram: boolean;
+	disableWebPreviewOnTelegram?: boolean;
 	useEmbeds: string;
 	serverId?: string;
 }
@@ -15,6 +16,7 @@ export class BridgeSettingsDiscord {
 	public relayJoinMessages: boolean;
 	public relayLeaveMessages: boolean;
 	public crossDeleteOnTelegram: boolean;
+	public disableWebPreviewOnTelegram: undefined | boolean;
 	public useEmbeds: string;
 
 	/**
@@ -44,6 +46,9 @@ export class BridgeSettingsDiscord {
 
 		/** Whether or not to delete messages on Telegram when a message is deleted on Discord */
 		this.crossDeleteOnTelegram = settings.crossDeleteOnTelegram;
+
+		/** Whether to enable web preview relaying to Telegram */
+		this.disableWebPreviewOnTelegram = settings.disableWebPreviewOnTelegram;
 
 		/** Whether to use Embeds when posting on Discord */
 		this.useEmbeds = settings.useEmbeds;

--- a/src/discord2telegram/setup.ts
+++ b/src/discord2telegram/setup.ts
@@ -247,6 +247,7 @@ export function setup(
 						const tgMessage = await tgBot.telegram.sendMessage(bridge.telegram.chatId, textToSend, {
 							reply_to_message_id: +replyId,
 							parse_mode: "HTML",
+							disable_web_page_preview: bridge.discord.disableWebPreviewOnTelegram,
 							message_thread_id: bridge.tgThread
 						});
 						messageMap.insert(
@@ -373,7 +374,7 @@ export function setup(
 						await tgBot.telegram.sendMessage(bridge.telegram.chatId, text, {
 							reply_to_message_id: +replyId,
 							parse_mode: "HTML",
-							disable_web_page_preview: true,
+							disable_web_page_preview: bridge.discord.disableWebPreviewOnTelegram,
 							message_thread_id: bridge.tgThread
 						});
 						// }

--- a/src/settings/DiscordSettings.ts
+++ b/src/settings/DiscordSettings.ts
@@ -152,6 +152,7 @@ export class DiscordSettings {
 			suppressThisIsPrivateBotMessage: false,
 			enableCustomStatus: false,
 			customStatusMessage: "TediCross",
+			disableWebPreviewOnTelegram: false,
 			useEmbeds: "auto"
 		};
 	}

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -488,9 +488,7 @@ export const handleEdits = createMessageHandler(async (ctx: TediCrossContext, br
 				const sendObject: DiscordMessage = {};
 
 				const useEmbeds =
-					((messageText.length > 2000 && prepared.bridge.discord.useEmbeds !== "never") ||
-						prepared.hasLinks);
-
+					(messageText.length > 2000 && prepared.bridge.discord.useEmbeds !== "never") || prepared.hasLinks;
 
 				if (useEmbeds) {
 					const text =

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -489,8 +489,8 @@ export const handleEdits = createMessageHandler(async (ctx: TediCrossContext, br
 
 				const useEmbeds =
 					((messageText.length > 2000 && prepared.bridge.discord.useEmbeds !== "never") ||
-						prepared.hasLinks) &&
-					!R.isNil(prepared.file);
+						prepared.hasLinks);
+
 
 				if (useEmbeds) {
 					const text =
@@ -503,6 +503,24 @@ export const handleEdits = createMessageHandler(async (ctx: TediCrossContext, br
 					}
 					embeds.push(embed);
 
+					const photoEmbeds: any[] = [];
+
+					if (!R.isNil(prepared.file)) {
+						const files = prepared.files || [prepared.file];
+						let tempPhotoUrl: string = "";
+						for (const file of files) {
+							// only photo attachments can be used as embeds
+							if (file.description === "photo") {
+								tempPhotoUrl = file.attachment;
+								photoEmbeds.push(new EmbedBuilder().setImage(tempPhotoUrl));
+							}
+						}
+						// if only 1 photo - set it into Embed
+						if (photoEmbeds.length === 1) {
+							embeds[0].setImage(tempPhotoUrl);
+						}
+					}
+
 					sendObject.embeds = embeds;
 
 					// trying to send prepared message
@@ -510,7 +528,7 @@ export const handleEdits = createMessageHandler(async (ctx: TediCrossContext, br
 						if (typeof dcMessage.edit !== "function") {
 							ctx.TediCross.logger.error("dcMessage.edit is not a function");
 						} else {
-							await dcMessage.edit(sendObject as MessageEditOptions);
+							await dcMessage.edit(sendObject);
 						}
 					} catch (err: any) {
 						ctx.TediCross.logger.error(err);

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -104,28 +104,6 @@ export const chatinfo = (ctx: Context) => {
 		.catch(ignoreAlreadyDeletedError as any);
 };
 
-export const channelChatInfo = (ctx: Context, next: () => void) => {
-	if ((ctx as any).update?.channel_post) {
-		if ((ctx as any).update.channel_post.text?.indexOf("/chatinfo") === 0) {
-			ctx.reply(`chatID: ${(ctx as any).update.channel_post.chat.id}`)
-				// Wait some time
-				.then(sleepOneMinute)
-				// Delete the info and the command
-				.then(message =>
-					Promise.all([
-						// Delete the info
-						deleteMessage(ctx, message),
-						// Delete the command
-						ctx.deleteMessage()
-					])
-				)
-				.catch(ignoreAlreadyDeletedError as any);
-			return;
-		}
-	}
-	next();
-};
-
 /**
  * Replies to a command with info about the thread
  *

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -104,6 +104,28 @@ export const chatinfo = (ctx: Context) => {
 		.catch(ignoreAlreadyDeletedError as any);
 };
 
+export const channelChatInfo = (ctx: Context, next: () => void) => {
+	if ((ctx as any).update?.channel_post) {
+		if ((ctx as any).update.channel_post.text?.indexOf("/chatinfo") === 0) {
+			ctx.reply(`chatID: ${(ctx as any).update.channel_post.chat.id}`)
+				// Wait some time
+				.then(sleepOneMinute)
+				// Delete the info and the command
+				.then(message =>
+					Promise.all([
+						// Delete the info
+						deleteMessage(ctx, message),
+						// Delete the command
+						ctx.deleteMessage()
+					])
+				)
+				.catch(ignoreAlreadyDeletedError as any);
+			return;
+		}
+	}
+	next();
+};
+
 /**
  * Replies to a command with info about the thread
  *
@@ -112,7 +134,7 @@ export const chatinfo = (ctx: Context) => {
 export const threadinfo = (ctx: Context) => {
 	// Reply with the info
 	if (ctx.message?.message_thread_id) {
-		ctx.reply(`chatID: ${ctx.message.chat.id}\nthreadID: ${ctx.message.message_thread_id}`)
+		ctx.reply(`chatID: ${ctx.message.chat?.id}\nthreadID: ${ctx.message.message_thread_id}`)
 			// Wait some time
 			.then(sleepOneMinute)
 			// Delete the info and the command

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -315,7 +315,11 @@ export const relayMessage = (ctx: TediCrossContext) => {
 				let embeds: EmbedBuilder[] = [];
 				const photoEmbeds: EmbedBuilder[] = [];
 				// build text embed
-				embeds.push(new EmbedBuilder().setTitle(prepared.header).setDescription(text));
+				const embed = new EmbedBuilder().setDescription(text);
+				if (prepared.header) {
+					embed.setTitle(prepared.header);
+				}
+				embeds.push(embed);
 				// process attached files
 				if (!R.isNil(prepared.file)) {
 					const files = prepared.files || [prepared.file];
@@ -414,6 +418,7 @@ export const relayMessage = (ctx: TediCrossContext) => {
 				dcMessage?.id
 			);
 		} catch (err: any) {
+			console.log(err);
 			ctx.TediCross.logger.error(
 				`Could not relay a message to Discord on bridge ${prepared.bridge.name}: ${err.message}`
 			);
@@ -485,7 +490,10 @@ export const handleEdits = createMessageHandler(async (ctx: TediCrossContext, br
 				const sendObject: DiscordMessage = {};
 				if (messageText.length > 2000 || prepared.hasLinks) {
 					const text = prepared.text.length > 4096 ? prepared.text.substring(0, 4090) + "..." : prepared.text;
-					const embed = new EmbedBuilder().setTitle(prepared.header).setDescription(text);
+					const embed = new EmbedBuilder().setDescription(text);
+					if (prepared.header) {
+						embed.setTitle(prepared.header);
+					}
 					sendObject.embeds = [embed];
 				} else {
 					sendObject.content = messageText;

--- a/src/telegram2discord/endwares.ts
+++ b/src/telegram2discord/endwares.ts
@@ -418,9 +418,8 @@ export const relayMessage = (ctx: TediCrossContext) => {
 				dcMessage?.id
 			);
 		} catch (err: any) {
-			console.log(err);
 			ctx.TediCross.logger.error(
-				`Could not relay a message to Discord on bridge ${prepared.bridge.name}: ${err.message}`
+				`Could not relay a message to Discord on bridge ${prepared.bridge.name}: ${err}`
 			);
 		}
 	})(ctx.tediCross.prepared);

--- a/src/telegram2discord/handleEntities.ts
+++ b/src/telegram2discord/handleEntities.ts
@@ -35,10 +35,10 @@ export async function handleEntities(text: string, entities: MessageEntity[], dc
 	let firstLink = true;
 	const regExpCaret = /(\r\n|\r|\n)$/i;
 	for (const e of entities) {
-		const beginIndex = e.offset;
+		let beginIndex = e.offset;
 		const part = text.substring(beginIndex, e.offset + e.length);
-		const endIndex = e.offset + part.trim().length;
-		const prefix = tagsArray[beginIndex] || "";
+		let endIndex = e.offset + part.trim().length;
+		let prefix = tagsArray[beginIndex] || "";
 		let suffix = tagsArray[endIndex] || "";
 
 		switch (e.type) {
@@ -55,11 +55,11 @@ export async function handleEntities(text: string, entities: MessageEntity[], dc
 					const dcRole = channel.guild.roles.cache.find(findFn("name", mentionable));
 
 					if (!R.isNil(dcUser)) {
-						tagsArray[beginIndex] = `${prefix}<@${dcUser.id}>`;
+						tagsArray[beginIndex + 1] = `${prefix}<@${dcUser.id}>`;
 					} else if (!R.isNil(dcRole)) {
-						tagsArray[beginIndex] = `${prefix}<@&${dcRole.id}>`;
+						tagsArray[beginIndex + 1] = `${prefix}<@&${dcRole.id}>`;
 					} else {
-						tagsArray[beginIndex] = `${part}`;
+						tagsArray[beginIndex + 1] = `${part}`;
 					}
 					skipIndex = skipIndex.concat(
 						Array(e.length)
@@ -86,6 +86,12 @@ export async function handleEntities(text: string, entities: MessageEntity[], dc
 				break;
 			}
 			case "text_link": {
+				// hard fix
+				if (part.indexOf(" ") === 0) {
+					beginIndex++;
+					endIndex++;
+					prefix = "";
+				}
 				if (part.trim() === e.url.trim()) {
 					skipIndex = skipIndex.concat(
 						Array(e.length)
@@ -101,10 +107,10 @@ export async function handleEntities(text: string, entities: MessageEntity[], dc
 				}
 
 				if (firstLink) {
-					tagsArray[endIndex] = `](${e.url})` + suffix;
+					tagsArray[endIndex] = `](${e.url.trim()})` + suffix;
 					firstLink = false;
 				} else {
-					tagsArray[endIndex] = `](<${e.url}>)` + suffix;
+					tagsArray[endIndex] = `](<${e.url.trim()}>)` + suffix;
 				}
 				hasLinks = bridge.discord.useEmbeds !== "never";
 				break;

--- a/src/telegram2discord/setup.ts
+++ b/src/telegram2discord/setup.ts
@@ -7,9 +7,9 @@ import { Client } from "discord.js";
 import { MessageMap } from "../MessageMap";
 import { BridgeMap } from "../bridgestuff/BridgeMap";
 import { Settings } from "../settings/Settings";
-import * as telegraf from "telegraf";
 import {
 	chatinfo,
+	channelChatInfo,
 	threadinfo,
 	handleEdits,
 	leftChatMember,
@@ -192,9 +192,9 @@ export function setup(
 			tgBot.catch((err: any) => {
 				// The docs says timeout errors should always be rethrown
 				// @ts-ignore TODO: Telefraf does not exprt the TimoutError, alternative implementation needed
-				if (err instanceof telegraf.TimeoutError) {
-					throw err;
-				}
+				// if (err instanceof telegraf.TimeoutError) {
+				// 	throw err;
+				// }
 
 				// Log other errors, but don't do anything with them
 				console.error(err);

--- a/src/telegram2discord/setup.ts
+++ b/src/telegram2discord/setup.ts
@@ -15,8 +15,7 @@ import {
 	leftChatMember,
 	newChatMembers,
 	relayMessage,
-	TediCrossContext,
-	channelChatInfo
+	TediCrossContext
 } from "./endwares";
 import { BotCommand, ChatAdministratorRights } from "telegraf/types";
 

--- a/src/telegram2discord/setup.ts
+++ b/src/telegram2discord/setup.ts
@@ -192,12 +192,9 @@ export function setup(
 			tgBot.catch((err: any) => {
 				// The docs says timeout errors should always be rethrown
 				// @ts-ignore TODO: Telefraf does not exprt the TimoutError, alternative implementation needed
-				// if (err instanceof telegraf.TimeoutError) {
-				// 	throw err;
-				// }
 
 				// Log other errors, but don't do anything with them
-				console.error(err);
+				logger.error(err);
 			});
 		})
 		// Start getting updates

--- a/src/telegram2discord/setup.ts
+++ b/src/telegram2discord/setup.ts
@@ -9,13 +9,13 @@ import { BridgeMap } from "../bridgestuff/BridgeMap";
 import { Settings } from "../settings/Settings";
 import {
 	chatinfo,
-	channelChatInfo,
 	threadinfo,
 	handleEdits,
 	leftChatMember,
 	newChatMembers,
 	relayMessage,
-	TediCrossContext
+	TediCrossContext,
+	channelChatInfo
 } from "./endwares";
 import { BotCommand, ChatAdministratorRights } from "telegraf/types";
 


### PR DESCRIPTION
1. Enable preview for the first link only in the regular message (when useEmbeds set to 'never'). So if the user wants to see link previews - he should disable embeds in bot config file.
2. Markdown link format works pretty good in regular messages, except the one, when link caption = link url (when text link auto formatted as link by Telegram). So in this solution is to replace full URL in link caption with word 'link' - in that case discord displays link correctly.