### PR TITLE
fix d2t relaying both redirection

### DIFF
--- a/src/telegram2discord/middlewares.ts
+++ b/src/telegram2discord/middlewares.ts
@@ -219,7 +219,7 @@ function addBridgesToContext(ctx: TediCrossContext, next: () => void) {
  * @param next Function to pass control to next middleware
  */
 function removeD2TBridges(ctx: TediCrossContext, next: () => void) {
-	ctx.tediCross.bridges = R.reject(R.propEq("direction", Bridge.DIRECTION_DISCORD_TO_TELEGRAM))(
+	ctx.tediCross.bridges = R.reject(R.propEq( Bridge.DIRECTION_DISCORD_TO_TELEGRAM, "direction"))(
 		ctx.tediCross.bridges
 	);
 

--- a/src/telegram2discord/middlewares.ts
+++ b/src/telegram2discord/middlewares.ts
@@ -219,7 +219,7 @@ function addBridgesToContext(ctx: TediCrossContext, next: () => void) {
  * @param next Function to pass control to next middleware
  */
 function removeD2TBridges(ctx: TediCrossContext, next: () => void) {
-	ctx.tediCross.bridges = R.reject(R.propEq( Bridge.DIRECTION_DISCORD_TO_TELEGRAM, "direction"))(
+	ctx.tediCross.bridges = R.reject(R.propEq(Bridge.DIRECTION_DISCORD_TO_TELEGRAM, "direction"))(
 		ctx.tediCross.bridges
 	);
 


### PR DESCRIPTION
Saw d2t was relaying both directions and apparently the params order were wrong causing objects to not be filtered from bridges.