### PR TITLE
Fix spurious read of undefined when trying to clean up old ThisIsPrivateBot messages

### DIFF
--- a/src/telegram2discord/middlewares.ts
+++ b/src/telegram2discord/middlewares.ts
@@ -277,6 +277,10 @@ function removeBridgesIgnoringLeaveMessages(ctx: TediCrossContext, next: () => v
  * @param next Function to pass control to next middleware
  */
 function informThisIsPrivateBot(ctx: TediCrossContext, next: () => void) {
+	if (ctx.TediCross.settings.telegram.suppressThisIsPrivateBotMessage) {
+		// Monkeypatch for the issue below
+		return;
+	}
 	R.ifElse(
 		// If there are no bridges
 		//@ts-ignore
@@ -311,6 +315,7 @@ function informThisIsPrivateBot(ctx: TediCrossContext, next: () => void) {
 							console.log(`Error send tg message: ${err}`);
 						});
 				} else {
+					// FIXME: Sometimes, this crashes with "Cannot read properties of undefined (reading 'chat')", see monkeypatch above
 					ctx.TediCross.antiInfoSpamSet.delete(ctx.message!.chat.id);
 				}
 			}


### PR DESCRIPTION
# Description

I'm running the latest version of TediCross, and it just crashed repeatedly with the error:

```
/path/to/TediCross/dist/telegram2discord/middlewares.js:279
            ctx.TediCross.antiInfoSpamSet.delete(ctx.message.chat.id);
                                                             ^

TypeError: Cannot read properties of undefined (reading 'chat')
    at /path/to/TediCross/dist/telegram2discord/middlewares.js:279:62
    at when (/path/to/TediCross/node_modules/ramda/src/when.js:31:20)
    at /path/to/TediCross/node_modules/ramda/src/internal/_curry3.js:27:18
    at f1 (/path/to/TediCross/node_modules/ramda/src/internal/_curry1.js:15:17)
    at _ifElse (/path/to/TediCross/node_modules/ramda/src/ifElse.js:32:54)
    at f1 (/path/to/TediCross/node_modules/ramda/src/internal/_curry1.js:15:17)
    at informThisIsPrivateBot (/path/to/TediCross/dist/telegram2discord/middlewares.js:283:10)
    at execute (/path/to/TediCross/node_modules/telegraf/lib/composer.js:518:23)
    at /path/to/TediCross/node_modules/telegraf/lib/composer.js:519:27
    at execute (/path/to/TediCross/node_modules/telegraf/lib/composer.js:518:23)
```

Apparently, `ctx.message` is `null` for some reason, and that causes the crash. I guess the TypeScript code actually acknowledges that `message` is a nullable type, but for some reason asserts that it is nonnull:

```
								.then(() => ctx.TediCross.antiInfoSpamSet.delete(ctx.message!.chat.id))
```

I don't use this feature, so I simply insert a "return" at the top to make everything work. This PR is a simple monkeypatch to make it work, in case you run into the same issue.

I guess the correct way to deal with this is to check whether `ctx.message` is null, do nothing if null, and remove it only if nonnull. However, I don't fully understand all the implications of that.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

"Works for me", since it makes the crash go away.

I don't understand what caused the issue in the first place.

I've been running TediCross successfully for several months without crash, then I added a bunch of new bridges at the same time, it ran for 16 hours without issues (bridging a few hundred messages during that time), then crashed, and insta-crashed five times during the automated restarts.

I don't know how to reproduce it. One way might be to inject a `null` into the cache between restarts? Dunno.

# Checklist:

- [ ] My code follows the style guidelines of this project (dunno, probably not since it introduces dead code)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (none necessary)
- [ ] My changes generate no new warnings (probably not, due to dead code)
- [X] Any dependent changes have been merged and published in downstream modules (none)

# My config

Here's a censored version of my config:

```yaml
telegram:
  useFirstNameInsteadOfUsername: true
  colonAfterSenderName: true
  skipOldMessages: false
  sendEmojiWithStickers: true
  useCustomEmojiFilter: false
  replaceAtWithHash: false
  replaceExcessiveSpaces: true
  removeNewlineSpaces: false
  suppressFileTooBigMessages: false
  suppressThisIsPrivateBotMessage: true
  token: <lolnope>
discord:
  skipOldMessages: false
  useNickname: true
  replyLength: 100
  maxReplyLines: 2
  suppressThisIsPrivateBotMessage: true
  enableCustomStatus: true
  customStatusMessage: blahblah
  useEmbeds: auto
  token: <lolnope>
debug: true
messageTimeoutAmount: 24
messageTimeoutUnit: hours
persistentMessageMap: true
bridges:
  - name: Test bridge
    direction: both
    telegram:
      chatId: -1001234567890
      relayJoinMessages: false
      relayLeaveMessages: false
      sendUsernames: true
      crossDeleteOnDiscord: true
    discord:
      channelId: '123456789012345678'
      relayJoinMessages: false
      relayLeaveMessages: false
      sendUsernames: true
      crossDeleteOnTelegram: true
      disableWebPreviewOnTelegram: false
      useEmbeds: auto
<a dozen more bridges>
```